### PR TITLE
Fix Deprecation Issues

### DIFF
--- a/supply-chain/README.md
+++ b/supply-chain/README.md
@@ -32,7 +32,7 @@ Update the `truffle-config.js` with the correct url with the basic auth username
   vmware: {
     network_id: "*",
     provider: () => new Web3.providers.HttpProvider(
-      "https://<username>:<api-token>@<hostname-fqdn>/api/blockchains/<blockchain-id>/concord/eth"
+      "https://<username>:<api-token>@<hostname>/api/blockchains/<blockchain-id>/concord/eth"
     )
   },
 ```
@@ -61,6 +61,13 @@ Update the environment BC_URL endpoint in the `docker-compose.yml` file to point
 
 ```
 
+Due to authentication happening in the browser and we don't have a backend fetching access tokens for us, we need to add `supply-chain.vmware.com` to our `/etc/hosts` to get past a browser CORS issue.
+
+So in `/etc/hosts` add:
+
+```
+127.0.0.1 supply-chain.vmware.com
+```
 
 Then start the server.
 
@@ -69,7 +76,7 @@ docker-compose up
 ```
 ![Docker Up](./static/docker-compose-up.png "Docker Up")
 
-Finally, open [localhost:4200](http://localhost:4200) in your browser.
+Finally, open [supply-chain.vmware.com:4200](http://supply-chain.vmare.com:4200) in your browser.
 
 NOTE: You may need to open an ssh tunnel if you are running on a separate VM
 

--- a/supply-chain/src/app/auth/auth.service.spec.ts
+++ b/supply-chain/src/app/auth/auth.service.spec.ts
@@ -6,13 +6,14 @@
 
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from './auth.service';
 import { BlockchainService } from './../core/blockchain/blockchain.service';
 
 describe('AuthService', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule],
+    imports: [HttpClientTestingModule, RouterTestingModule],
     providers: [BlockchainService]
   }));
 

--- a/supply-chain/src/app/auth/login/login.component.html
+++ b/supply-chain/src/app/auth/login/login.component.html
@@ -12,6 +12,9 @@ The full license information can be found in LICENSE in the root directory of th
             <h5 class="hint">{{ 'auth.description' | translate }}</h5>
         </section>
         <div  class="login-group">
+            <clr-input-container>
+                <input #refresh type="text" name="blockchainId" clrInput placeholder="Blockchain ID" formControlName="blockchainId"/>
+            </clr-input-container>
             <clr-password-container>
                 <input #refresh type="password" name="refresh" clrPassword placeholder="Refresh Token" formControlName="refresh"/>
             </clr-password-container>

--- a/supply-chain/src/app/auth/login/login.component.ts
+++ b/supply-chain/src/app/auth/login/login.component.ts
@@ -21,6 +21,7 @@ export class LoginComponent implements OnInit {
 
   loginForm: FormGroup = new FormGroup({
       refresh: new FormControl('', Validators.required),
+      blockchainId: new FormControl('', Validators.required),
   });
 
   logginIn: boolean;
@@ -37,7 +38,7 @@ export class LoginComponent implements OnInit {
   onSubmit() {
     this.logginIn = true;
     this.authService
-      .loginLocally(this.loginForm.get('refresh').value)
+      .loginLocally(this.loginForm.get('refresh').value, this.loginForm.get('blockchainId').value)
       .subscribe(response => {
         this.logginIn = false;
         this.router.navigate(['/home']);

--- a/supply-chain/src/app/core/blockchain/blockchain.service.spec.ts
+++ b/supply-chain/src/app/core/blockchain/blockchain.service.spec.ts
@@ -6,6 +6,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { MockTranslateModule } from '../../mocks/mock-translate.module';
 
 import { BlockchainService } from './blockchain.service';
@@ -16,7 +17,8 @@ describe('BlockchainService', () => {
   beforeEach(() => TestBed.configureTestingModule({
     imports: [
       HttpClientTestingModule,
-      MockTranslateModule
+      MockTranslateModule,
+      RouterTestingModule
     ],
     providers: [
       AuthService,

--- a/supply-chain/src/app/core/blockchain/blockchain.service.ts
+++ b/supply-chain/src/app/core/blockchain/blockchain.service.ts
@@ -194,9 +194,10 @@ export class BlockchainService {
       {geo: [151.21, -33.868], region: 'Sydney', organization: 'Supplier Corp'},
       {geo: [8.67972, 45.836507], region: 'Frankfurt', organization: 'Customs'},
     ];
+    const blockchainId = localStorage.getItem('blockchainId');
 
     return this.http.get(
-      `${environment.path}/concord/members`,
+      `${environment.path}/api/blockchains/${blockchainId}/replicas`,
       this.getHttpOptions()
     ).pipe(
       map(nodes => {
@@ -486,23 +487,7 @@ export class BlockchainService {
     const self = this;
     return function(error, value) {
       if (error) {
-        const errorMessage = error.message ? JSON.parse(error.message.replace('Invalid JSON RPC response: ', '')) : {};
-        // Retry access token once more
-        if (errorMessage && errorMessage.status === 401 && !retry) {
-          console.log('retrying');
-
-          const reset = async () => {
-            await self.authService.refreshAccessToken().toPromise();
-            self.initConnection();
-          };
-          reset();
-          self.callbackToResolve(resolve, reject, true);
-
-        } else {
-          console.log('reject');
-          reject(error);
-        }
-
+        reject(error);
       } else {
         resolve(value);
       }

--- a/supply-chain/src/app/order/order-detail/order-detail.component.spec.ts
+++ b/supply-chain/src/app/order/order-detail/order-detail.component.spec.ts
@@ -6,6 +6,7 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
 
 import { ClarityModule } from '@clr/angular';
@@ -27,7 +28,8 @@ describe('OrderDetailComponent', () => {
         ClarityModule,
         SharedModule,
         TranslateModule.forRoot(),
-        HttpClientTestingModule
+        HttpClientTestingModule,
+        RouterTestingModule
       ],
       declarations: [
         OrderDetailComponent,

--- a/supply-chain/src/app/order/order-list/order-list.component.ts
+++ b/supply-chain/src/app/order/order-list/order-list.component.ts
@@ -83,7 +83,13 @@ export class OrderListComponent implements OnDestroy, OnInit {
   }
 
   private replaceOrder(order: Order) {
-    const orderIndex = this.orders.map((o) => o.id).indexOf(order.id);
+    const orderIdList = this.orders.map((o) => o.id);
+    if (orderIdList.length === 0) {
+      return false;
+    }
+
+    const orderIndex = orderIdList.indexOf(order.id);
+
     if (orderIndex >= 0) {
       this.orders.splice(orderIndex, 1, order);
       this._gridSelectedOrder = order;

--- a/supply-chain/src/app/order/order.component.spec.ts
+++ b/supply-chain/src/app/order/order.component.spec.ts
@@ -6,6 +6,7 @@
 
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { ActivatedRoute } from '@angular/router';
 
 import { MockSharedModule } from '../shared/shared.module';
@@ -23,7 +24,11 @@ describe('OrderComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      imports: [MockSharedModule, HttpClientTestingModule],
+      imports: [
+        MockSharedModule,
+        HttpClientTestingModule,
+        RouterTestingModule
+      ],
       declarations: [
         OrderComponent,
         OrderDetailComponent,

--- a/supply-chain/src/app/order/shared/order-resolve.service.spec.ts
+++ b/supply-chain/src/app/order/shared/order-resolve.service.spec.ts
@@ -6,6 +6,7 @@
 
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { OrderResolver } from './order-resolve.service';
 import { BlockchainService } from './../../core/blockchain/blockchain.service';
@@ -14,7 +15,11 @@ import { MockTranslateModule } from './../../mocks/mock-translate.module';
 
 describe('OrderResolveService', () => {
   beforeEach(() => TestBed.configureTestingModule({
-    imports: [HttpClientTestingModule, MockTranslateModule],
+    imports: [
+      HttpClientTestingModule,
+      MockTranslateModule,
+      RouterTestingModule
+    ],
     providers: [
       BlockchainService,
       OrderResolver,


### PR DESCRIPTION
- The members and concord/eth api’s had been deprecated, and we need to now specify a blockchain ID in order to get things to work.
- Updated the readme to let users know they need to have supply-chain.vmware.com in `/etc/hosts` in order for it to work
- Added blockchain id field to the login
- Make sure a redirect to `/login` happens

Signed-off-by: Matthew Harrison <mharrison@vmware.com>