### PR TITLE
Sample load test code using web3j

### DIFF
--- a/hardhat/contracts/SecurityToken.sol
+++ b/hardhat/contracts/SecurityToken.sol
@@ -4,8 +4,6 @@ pragma solidity >=0.6.0 <0.8.0;
 
 import "./ERC20.sol";
 
-import "hardhat/console.sol";
-
 contract SecurityToken is ERC20 {
 
     constructor (
@@ -13,7 +11,6 @@ contract SecurityToken is ERC20 {
       string memory symbol,
       uint256 initialSupply
     ) public ERC20(name, symbol) {
-      console.log("Deploying ERC20 Token:", name, symbol);
       _mint(msg.sender, initialSupply * (10 ** uint256(decimals())));
     }
 

--- a/web3j/.gitignore
+++ b/web3j/.gitignore
@@ -1,0 +1,3 @@
+target
+.idea
+web3j.iml

--- a/web3j/CONTRIBUTING.md
+++ b/web3j/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+## Code style plugin
+
+The project uses [Google's code styleguide](https://google.github.io/styleguide/javaguide.html) for
+Java files. Maven plugin [google-java-format](https://github.com/google/google-java-format) checks
+for non-complying files during the build and suggests the following command to fix it.
+
+```shell
+$ mvn com.coveo:fmt-maven-plugin:format
+```
+
+## License plugin
+
+Following are few useful commands
+from [License Maven Plugin](https://www.mojohaus.org/license-maven-plugin/).
+
+```shell
+$ mvn license:update-project-license
+$ mvn license:update-file-header
+$ mvn license:add-third-party
+```

--- a/web3j/LICENSE.txt
+++ b/web3j/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021, VMware
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/web3j/README.md
+++ b/web3j/README.md
@@ -1,0 +1,34 @@
+# ERC-20 Load Testing Tool
+
+# Overview
+
+This is a sample load testing tool to
+transfer [SecurityToken](../hardhat/contracts/SecurityToken.sol)
+from a sender to a recipient account at a controlled pace
+using [web3j](https://github.com/web3j/web3j) library.
+
+# Setup
+
+Install the following tools.
+
+* [JDK 11](https://adoptopenjdk.net/installation.html)
+* [Maven](https://maven.apache.org/install.html)
+
+# Build
+
+```shell
+$ git clone https://github.com/vmware-samples/vmware-blockchain-samples.git
+$ cd vmware-blockchain-samples/web3j
+$ mvn clean install
+```
+
+# Run
+
+Configure [application.yml](src/main/resources/config/application.yml) as per your test requirement
+and Ethereum client deployment. Run the following command to start the load test. Monitor the test
+using web UI (default port: 8080)
+
+```shell
+$ mvn spring-boot:run
+# Ctrl+C to stop once the test is done. 
+```

--- a/web3j/pom.xml
+++ b/web3j/pom.xml
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.vmware</groupId>
+  <artifactId>web3j</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <properties>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
+    <okhttp3.version>4.9.0</okhttp3.version>
+  </properties>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.4.3</version>
+  </parent>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-validation</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.web3j</groupId>
+      <artifactId>core</artifactId>
+      <version>4.8.4</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.18</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.web3j</groupId>
+      <artifactId>web3j-evm</artifactId>
+      <version>4.8.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.beust</groupId>
+          <artifactId>klaxon</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <!-- Failure to find com.beust:klaxon:jar:5.0.1 -->
+    <dependency>
+      <groupId>com.beust</groupId>
+      <artifactId>klaxon</artifactId>
+      <version>5.4</version>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.web3j</groupId>
+        <artifactId>web3j-maven-plugin</artifactId>
+        <version>4.6.5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>generate-sources</goal>
+            </goals>
+            <configuration>
+              <soliditySourceFiles>
+                <directory>../hardhat/contracts</directory>
+              </soliditySourceFiles>
+              <sourceDestination>target/generated-sources</sourceDestination>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>target/generated-sources</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.google.googlejavaformat</groupId>
+            <artifactId>google-java-format</artifactId>
+            <version>1.9</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <configuration>
+          <projectName>ERC-20 Load Testing Tool</projectName>
+          <organizationName>VMware</organizationName>
+          <inceptionYear>2021</inceptionYear>
+          <licenseName>mit</licenseName>
+          <failOnMissingHeader>true</failOnMissingHeader>
+          <roots>
+            <root>src/main/java</root>
+            <root>src/main/resources</root>
+          </roots>
+          <excludes>
+            <exclude>**/*.json</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check-file-header</goal>
+            </goals>
+            <phase>process-sources</phase>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+  </build>
+
+</project>

--- a/web3j/src/main/java/com/vmware/ethereum/Application.java
+++ b/web3j/src/main/java/com/vmware/ethereum/Application.java
@@ -1,0 +1,51 @@
+package com.vmware.ethereum;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import com.vmware.ethereum.service.WorkloadRunner;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@Slf4j
+@RequiredArgsConstructor
+@SpringBootApplication
+public class Application implements CommandLineRunner {
+
+  private final WorkloadRunner workload;
+
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
+
+  @Override
+  public void run(String[] args) {
+    workload.run();
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/config/AppConfig.java
+++ b/web3j/src/main/java/com/vmware/ethereum/config/AppConfig.java
@@ -1,0 +1,106 @@
+package com.vmware.ethereum.config;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.concurrent.CountDownLatch;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
+import okhttp3.logging.HttpLoggingInterceptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.web3j.abi.datatypes.Address;
+import org.web3j.crypto.CipherException;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.WalletUtils;
+import org.web3j.evm.Configuration;
+import org.web3j.evm.EmbeddedWeb3jService;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.http.HttpService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppConfig {
+
+  private final Web3jConfig config;
+
+  @Bean
+  public SSLSocketFactory createSslSocketFactory() throws GeneralSecurityException {
+    TrustManager[] trustManagers = InsecureTrustManagerFactory.INSTANCE.getTrustManagers();
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, trustManagers, new SecureRandom());
+    return sslContext.getSocketFactory();
+  }
+
+  @Bean
+  public OkHttpClient okHttpClient(SSLSocketFactory sslSocketFactory) {
+    TrustManager[] trustManagers = InsecureTrustManagerFactory.INSTANCE.getTrustManagers();
+    OkHttpClient.Builder builder = new OkHttpClient.Builder();
+    builder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustManagers[0]);
+    builder.hostnameVerifier((hostname, session) -> true);
+    builder.addInterceptor(new HttpLoggingInterceptor().setLevel(config.getLogLevel()));
+    return builder.build();
+  }
+
+  @Bean
+  public Credentials credentials() throws IOException, CipherException {
+    String privateKey = config.getPrivateKey();
+    if (!privateKey.isBlank()) {
+      log.info("Creating credentials from private key ..");
+      return Credentials.create(privateKey);
+    }
+
+    log.info("Loading credentials from wallet ..");
+    return WalletUtils.loadCredentials(config.getWalletPassword(), config.getWalletFile());
+  }
+
+  @Bean
+  public Web3j web3j(OkHttpClient okHttpClient, Credentials credentials) {
+    String url = config.getUrl();
+    if (!url.isBlank()) {
+      return Web3j.build(new HttpService(url, okHttpClient));
+    }
+
+    Configuration configuration =
+        new Configuration(new Address(credentials.getAddress()), config.getEthFund());
+    return Web3j.build(new EmbeddedWeb3jService(configuration));
+  }
+
+  @Bean
+  public CountDownLatch countDownLatch(WorkloadConfig config) {
+    return new CountDownLatch(config.getTransactions());
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/config/TokenConfig.java
+++ b/web3j/src/main/java/com/vmware/ethereum/config/TokenConfig.java
@@ -1,0 +1,53 @@
+package com.vmware.ethereum.config;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+@Setter
+@Getter
+@ToString
+@Validated
+@Configuration
+@ConfigurationProperties("token")
+public class TokenConfig {
+
+  @NotEmpty private String name;
+  @NotEmpty private String symbol;
+  @Positive private long initialSupply;
+  @NotEmpty private String recipient;
+  @Positive private long amount;
+  @Positive private long gasPrice;
+  @Positive private long gasLimit;
+}

--- a/web3j/src/main/java/com/vmware/ethereum/config/Web3jConfig.java
+++ b/web3j/src/main/java/com/vmware/ethereum/config/Web3jConfig.java
@@ -1,0 +1,54 @@
+package com.vmware.ethereum.config;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import java.io.File;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import okhttp3.logging.HttpLoggingInterceptor.Level;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+@Setter
+@Getter
+@ToString
+@Validated
+@Configuration
+@ConfigurationProperties("web3j")
+public class Web3jConfig {
+
+  @NotNull private String url;
+  @NotNull private File walletFile;
+  @NotNull private String walletPassword;
+  @PositiveOrZero private long ethFund;
+  @NotNull private String privateKey;
+  @NotNull private Level logLevel;
+}

--- a/web3j/src/main/java/com/vmware/ethereum/config/WorkloadConfig.java
+++ b/web3j/src/main/java/com/vmware/ethereum/config/WorkloadConfig.java
@@ -1,0 +1,50 @@
+package com.vmware.ethereum.config;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import java.time.Duration;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.validation.annotation.Validated;
+
+@Setter
+@Getter
+@Validated
+@Configuration
+@ConfigurationProperties("workload")
+public class WorkloadConfig {
+
+  @Positive private int transactions;
+  @NotNull private WorkloadModel model;
+  @PositiveOrZero private int loadFactor;
+  @NotNull private Duration progressInterval;
+}

--- a/web3j/src/main/java/com/vmware/ethereum/config/WorkloadModel.java
+++ b/web3j/src/main/java/com/vmware/ethereum/config/WorkloadModel.java
@@ -1,0 +1,32 @@
+package com.vmware.ethereum.config;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+public enum WorkloadModel {
+  OPEN,
+  CLOSED
+}

--- a/web3j/src/main/java/com/vmware/ethereum/controller/MainController.java
+++ b/web3j/src/main/java/com/vmware/ethereum/controller/MainController.java
@@ -1,0 +1,61 @@
+package com.vmware.ethereum.controller;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import com.vmware.ethereum.config.Web3jConfig;
+import com.vmware.ethereum.model.EthClientInfo;
+import com.vmware.ethereum.service.ProgressService;
+import com.vmware.ethereum.service.SecureTokenApi;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Controller
+@RequiredArgsConstructor
+public class MainController {
+
+  private final Web3jConfig config;
+  private final SecureTokenApi api;
+  private final ProgressService service;
+
+  @GetMapping("/")
+  public String testReport(Model model) {
+    model.addAttribute("progress", service.getProgress());
+    return "report";
+  }
+
+  @ModelAttribute("ethInfo")
+  public EthClientInfo getEthClientInfo() {
+    EthClientInfo info = new EthClientInfo();
+    info.setClientUrl(config.getUrl());
+    info.setClientVersion(api.getClientVersion());
+    info.setNetworkVersion(api.getNetVersion());
+    return info;
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/controller/TestController.java
+++ b/web3j/src/main/java/com/vmware/ethereum/controller/TestController.java
@@ -1,0 +1,53 @@
+package com.vmware.ethereum.controller;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
+import static reactor.core.publisher.Flux.interval;
+
+import com.vmware.ethereum.config.WorkloadConfig;
+import com.vmware.ethereum.model.ProgressReport;
+import com.vmware.ethereum.service.ProgressService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+
+@RestController
+@RequestMapping("/test")
+@RequiredArgsConstructor
+public class TestController {
+
+  private final ProgressService service;
+  private final WorkloadConfig config;
+
+  @GetMapping(path = "/progress", produces = TEXT_EVENT_STREAM_VALUE)
+  public Flux<ProgressReport> getProgress() {
+    return interval(config.getProgressInterval()).map(sequence -> service.getProgress());
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/model/EthClientInfo.java
+++ b/web3j/src/main/java/com/vmware/ethereum/model/EthClientInfo.java
@@ -1,0 +1,39 @@
+package com.vmware.ethereum.model;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class EthClientInfo {
+
+  private String clientUrl;
+  private String clientVersion;
+  private String networkVersion;
+}

--- a/web3j/src/main/java/com/vmware/ethereum/model/ProgressReport.java
+++ b/web3j/src/main/java/com/vmware/ethereum/model/ProgressReport.java
@@ -1,0 +1,57 @@
+package com.vmware.ethereum.model;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import com.vmware.ethereum.config.WorkloadModel;
+import java.time.Duration;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+public class ProgressReport {
+
+  private final int txTotal;
+  private final int txSuccess;
+  private final int txFailure;
+  private final String txErrors;
+  private final int txPending;
+
+  private final Duration elapsedTime;
+  private final Duration remainingTime;
+
+  private final WorkloadModel workloadModel;
+  private final int loadFactor;
+
+  private final long currentThroughput;
+  private final long currentLatency;
+
+  private final long averageThroughput;
+  private final long averageLatency;
+}

--- a/web3j/src/main/java/com/vmware/ethereum/service/ClosedWorkload.java
+++ b/web3j/src/main/java/com/vmware/ethereum/service/ClosedWorkload.java
@@ -1,0 +1,72 @@
+package com.vmware.ethereum.service;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ClosedWorkload implements WorkloadService {
+
+  private final WorkloadCommand command;
+  private final long transactions;
+  private final int concurrency;
+
+  private ExecutorService executor;
+
+  @Override
+  public void start() {
+    log.info("Running {} transaction at concurrency {} ..", transactions, concurrency);
+
+    executor =
+        new ThreadPoolExecutor(
+            concurrency,
+            concurrency,
+            0L,
+            MILLISECONDS,
+            new LinkedBlockingQueue<>(concurrency),
+            new CallerRunsPolicy());
+
+    for (int i = 0; i < transactions; i++) {
+      executor.submit(command);
+    }
+
+    log.info("Transactions submitted");
+  }
+
+  @Override
+  public void stop() {
+    executor.shutdown();
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/service/MetricsService.java
+++ b/web3j/src/main/java/com/vmware/ethereum/service/MetricsService.java
@@ -1,0 +1,161 @@
+package com.vmware.ethereum.service;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import static java.lang.Math.max;
+import static java.time.Duration.between;
+import static java.time.Duration.ofSeconds;
+import static java.time.Instant.now;
+
+import com.vmware.ethereum.config.WorkloadConfig;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.LongAdder;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.stereotype.Service;
+
+@Setter
+@Getter
+@Service
+public class MetricsService {
+
+  private final int totalCount;
+  private final AtomicInteger successCount;
+  private final AtomicInteger failureCount;
+  private final Map<String, AtomicInteger> errorToCount;
+  private final LongAdder totalLatency;
+
+  private final long periodInterval;
+  private final AtomicInteger periodCount;
+  private final LongAdder periodLatency;
+
+  private Instant startTime;
+  private Instant endTime;
+
+  public MetricsService(WorkloadConfig config) {
+    successCount = new AtomicInteger();
+    failureCount = new AtomicInteger();
+    errorToCount = new ConcurrentHashMap<>();
+    periodCount = new AtomicInteger();
+    totalLatency = new LongAdder();
+    periodLatency = new LongAdder();
+
+    totalCount = config.getTransactions();
+    periodInterval = config.getProgressInterval().getSeconds();
+  }
+
+  /** Increment transaction counts. */
+  public void updateTxStatus(boolean isStatusOK) {
+    if (isStatusOK) {
+      successCount.incrementAndGet();
+    } else {
+      failureCount.incrementAndGet();
+    }
+
+    periodCount.incrementAndGet();
+  }
+
+  /** Increment error count. */
+  public void updateTxError(String error) {
+    errorToCount.putIfAbsent(error, new AtomicInteger());
+    errorToCount.get(error).incrementAndGet();
+  }
+
+  /** Add to accumulated latency. */
+  public void updateTxLatency(long responseTimeMs) {
+    totalLatency.add(responseTimeMs);
+    periodLatency.add(responseTimeMs);
+  }
+
+  /** Get elapsed time of the test. */
+  public Duration getElapsedTime() {
+    if (endTime != null) {
+      return between(startTime, endTime);
+    }
+    return between(startTime, now());
+  }
+
+  /** Get remaining time of the test. */
+  public Duration getRemainingTime() {
+    return ofSeconds(getPendingCount() / max(getAverageThroughput(), 1));
+  }
+
+  /** Get total completed transactions. */
+  public int getCompletionCount() {
+    return successCount.get() + failureCount.get() + getErrorCount();
+  }
+
+  /** Get number of exceptions. */
+  private int getErrorCount() {
+    return errorToCount.values().stream().mapToInt(AtomicInteger::get).sum();
+  }
+
+  /** Get total pending transactions. */
+  public int getPendingCount() {
+    return totalCount - getCompletionCount();
+  }
+
+  /** Throughput for the test duration. */
+  public long getAverageThroughput() {
+    return getThroughput(getCompletionCount(), getElapsedTime().getSeconds());
+  }
+
+  /** Latency for the test duration. */
+  public long getAverageLatency() {
+    return getLatency(totalLatency, getCompletionCount());
+  }
+
+  /** Throughput for the current period. */
+  public long getPeriodThroughput() {
+    return getThroughput(periodCount.get(), periodInterval);
+  }
+
+  /** Latency for the current period. */
+  public long getPeriodLatency() {
+    return getLatency(periodLatency, periodCount.get());
+  }
+
+  /** Get transactions per second. */
+  private long getThroughput(int transactions, long seconds) {
+    return transactions / max(seconds, 1);
+  }
+
+  /** Get latency per transaction. */
+  private long getLatency(LongAdder cumulative, int transactions) {
+    return cumulative.sum() / max(transactions, 1);
+  }
+
+  /** Reset the counters for the next period. */
+  public void resetPeriodMetrics() {
+    periodCount.set(0);
+    periodLatency.reset();
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/service/OpenWorkload.java
+++ b/web3j/src/main/java/com/vmware/ethereum/service/OpenWorkload.java
@@ -1,0 +1,60 @@
+package com.vmware.ethereum.service;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import java.util.concurrent.ScheduledExecutorService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class OpenWorkload implements WorkloadService {
+
+  private final WorkloadCommand command;
+  private final long transactions;
+  private final int arrivalRate;
+
+  private ScheduledExecutorService executor;
+
+  @Override
+  public void start() {
+    log.info("Running {} transaction at arrival rate {}/sec ..", transactions, arrivalRate);
+    executor = newSingleThreadScheduledExecutor();
+    long periodUs = SECONDS.toMicros(1) / arrivalRate;
+    executor.scheduleAtFixedRate(command, 0, periodUs, MICROSECONDS);
+    log.info("Transactions scheduled");
+  }
+
+  @Override
+  public void stop() {
+    executor.shutdown();
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/service/ProgressService.java
+++ b/web3j/src/main/java/com/vmware/ethereum/service/ProgressService.java
@@ -1,0 +1,72 @@
+package com.vmware.ethereum.service;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import com.vmware.ethereum.config.WorkloadConfig;
+import com.vmware.ethereum.model.ProgressReport;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProgressService {
+
+  private final MetricsService metrics;
+  private final WorkloadConfig config;
+
+  /** Get progress report. */
+  public ProgressReport getProgress() {
+    ProgressReport progress = buildProgress();
+    metrics.resetPeriodMetrics();
+    return progress;
+  }
+
+  /** Build progress report. */
+  private ProgressReport buildProgress() {
+    return ProgressReport.builder()
+        .txTotal(config.getTransactions())
+        .txSuccess(metrics.getSuccessCount().get())
+        .txFailure(metrics.getFailureCount().get())
+        .txErrors(getErrors())
+        .txPending(metrics.getPendingCount())
+        .elapsedTime(metrics.getElapsedTime())
+        .remainingTime(metrics.getRemainingTime())
+        .workloadModel(config.getModel())
+        .loadFactor(config.getLoadFactor())
+        .currentThroughput(metrics.getPeriodThroughput())
+        .currentLatency(metrics.getPeriodLatency())
+        .averageThroughput(metrics.getAverageThroughput())
+        .averageLatency(metrics.getAverageLatency())
+        .build();
+  }
+
+  /** Formatted error count. */
+  private String getErrors() {
+    return Arrays.toString(metrics.getErrorToCount().entrySet().toArray());
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/service/SecureTokenApi.java
+++ b/web3j/src/main/java/com/vmware/ethereum/service/SecureTokenApi.java
@@ -1,0 +1,134 @@
+package com.vmware.ethereum.service;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import static java.math.BigInteger.valueOf;
+
+import com.vmware.ethereum.config.TokenConfig;
+import java.io.IOException;
+import java.math.BigInteger;
+import javax.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.web3j.crypto.Credentials;
+import org.web3j.model.SecurityToken;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.tx.gas.ContractGasProvider;
+import org.web3j.tx.gas.StaticGasProvider;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SecureTokenApi {
+
+  private final TokenConfig config;
+  private final Web3j web3j;
+  private final Credentials credentials;
+  private SecurityToken token;
+
+  @PostConstruct
+  public void init() {
+    log.info("Client version: {}", getClientVersion());
+    log.info("Gas price: {}", getGasPrice());
+    log.info("Net version: {}", getNetVersion());
+    log.info("Sender address: {}", credentials.getAddress());
+
+    token = deploy();
+  }
+
+  /** Deploy token. */
+  @SneakyThrows(Exception.class)
+  private SecurityToken deploy() {
+    log.info("Deploy: {}", config);
+
+    ContractGasProvider gasProvider =
+        new StaticGasProvider(valueOf(config.getGasPrice()), valueOf(config.getGasLimit()));
+
+    BigInteger initialSupply = valueOf(config.getInitialSupply());
+    SecurityToken securityToken =
+        SecurityToken.deploy(
+                web3j,
+                credentials,
+                gasProvider,
+                config.getName(),
+                config.getSymbol(),
+                initialSupply)
+            .send();
+
+    securityToken.getTransactionReceipt().ifPresent(receipt -> log.info("Receipt: {}", receipt));
+    return securityToken;
+  }
+
+  /** Transfer token. */
+  public TransactionReceipt transfer() throws Exception {
+    log.debug("Transferring token ..");
+    TransactionReceipt receipt =
+        token.transfer(config.getRecipient(), valueOf(config.getAmount())).send();
+    log.debug("Receipt: {}", receipt);
+    return receipt;
+  }
+
+  @SneakyThrows(IOException.class)
+  public String getNetVersion() {
+    return web3j.netVersion().send().getNetVersion();
+  }
+
+  @SneakyThrows(IOException.class)
+  private BigInteger getGasPrice() {
+    return web3j.ethGasPrice().send().getGasPrice();
+  }
+
+  @SneakyThrows(IOException.class)
+  public String getClientVersion() {
+    return web3j.web3ClientVersion().send().getWeb3ClientVersion();
+  }
+
+  /** Get current block number. */
+  @SneakyThrows(IOException.class)
+  public long getBlockNumber() {
+    return web3j.ethBlockNumber().send().getBlockNumber().longValue();
+  }
+
+  /** Get token balance of the sender. */
+  public long getSenderBalance() {
+    return getBalance(credentials.getAddress());
+  }
+
+  /** Get token balance of the recipient. */
+  public long getRecipientBalance() {
+    return getBalance(config.getRecipient());
+  }
+
+  /** Get token balance of the given address. */
+  @SneakyThrows(Exception.class)
+  private long getBalance(String account) {
+    return token.balanceOf(account).send().longValue();
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/service/WorkloadCommand.java
+++ b/web3j/src/main/java/com/vmware/ethereum/service/WorkloadCommand.java
@@ -1,0 +1,63 @@
+package com.vmware.ethereum.service;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import static java.time.Duration.between;
+import static java.time.Instant.now;
+
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkloadCommand implements Runnable {
+
+  private final SecureTokenApi api;
+  private final CountDownLatch countDownLatch;
+  private final MetricsService metrics;
+
+  @Override
+  public void run() {
+    Instant startTime = now();
+    try {
+      TransactionReceipt receipt = api.transfer();
+      metrics.updateTxStatus(receipt.isStatusOK());
+    } catch (Exception e) {
+      log.warn("{}", e.toString());
+      metrics.updateTxError(e.getClass().getSimpleName());
+    }
+
+    long responseTimeMs = between(startTime, now()).toMillis();
+    metrics.updateTxLatency(responseTimeMs);
+    countDownLatch.countDown();
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/service/WorkloadRunner.java
+++ b/web3j/src/main/java/com/vmware/ethereum/service/WorkloadRunner.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 VMware, all rights reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+package com.vmware.ethereum.service;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+import static com.vmware.ethereum.config.WorkloadModel.OPEN;
+import static java.time.Instant.now;
+
+import com.vmware.ethereum.config.WorkloadConfig;
+import java.util.concurrent.CountDownLatch;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WorkloadRunner {
+
+  private final WorkloadConfig config;
+  private final WorkloadCommand command;
+  private final SecureTokenApi api;
+
+  private final CountDownLatch countDownLatch;
+  private final MetricsService metrics;
+
+  /** Run the workload. */
+  @SneakyThrows(InterruptedException.class)
+  public void run() {
+    WorkloadService workload = createWorkload();
+    start(workload);
+    countDownLatch.await();
+    stop(workload);
+  }
+
+  /** Start the workload. */
+  private void start(WorkloadService workload) {
+    printBalance();
+    metrics.setStartTime(now());
+    workload.start();
+  }
+
+  /** Stop the workload. */
+  private void stop(WorkloadService workload) {
+    workload.stop();
+    metrics.setEndTime(now());
+    printReport();
+    printBalance();
+    log.info("Test is completed");
+  }
+
+  /** Create workload to run. */
+  private WorkloadService createWorkload() {
+    if (config.getModel() == OPEN) {
+      return new OpenWorkload(command, config.getTransactions(), config.getLoadFactor());
+    }
+    return new ClosedWorkload(command, config.getTransactions(), config.getLoadFactor());
+  }
+
+  /** Print token balance of the sender and the receiver. */
+  private void printBalance() {
+    log.info("Block number: {}", api.getBlockNumber());
+    log.info("Sender has {} tokens", api.getSenderBalance());
+    log.info("Recipient has {} tokens", api.getRecipientBalance());
+  }
+
+  /** Print report */
+  private void printReport() {
+    log.info("Test duration: {}", metrics.getElapsedTime());
+    log.info("Total: {}", metrics.getTotalCount());
+    log.info("OK: {}", metrics.getSuccessCount());
+    log.info("KO: {}", metrics.getFailureCount());
+    log.info("Errors: {}", metrics.getErrorToCount());
+
+    if (config.getModel() == OPEN) {
+      log.info("Arrival rate: {}/sec", config.getLoadFactor());
+    } else {
+      log.info("Concurrency: {}", config.getLoadFactor());
+    }
+
+    log.info("Avg throughput: {}/sec", metrics.getAverageThroughput());
+    log.info("Avg latency:  {} ms", metrics.getAverageLatency());
+  }
+}

--- a/web3j/src/main/java/com/vmware/ethereum/service/WorkloadService.java
+++ b/web3j/src/main/java/com/vmware/ethereum/service/WorkloadService.java
@@ -1,0 +1,34 @@
+package com.vmware.ethereum.service;
+
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+
+public interface WorkloadService {
+
+  void start();
+
+  void stop();
+}

--- a/web3j/src/main/resources/config/application.yml
+++ b/web3j/src/main/resources/config/application.yml
@@ -1,0 +1,33 @@
+workload:
+  model: OPEN  # either OPEN or CLOSED workload model
+  transactions: 1000 # Number of transactions (token transfers).
+  load-factor: 10 # arrival rate for OPEN model & concurrency for CLOSED model
+  progress-interval: 5s # interval for updating progress in web UI
+
+web3j:
+  url: # ethereum client endpoint (Note: Leave it blank in demo mode.)
+  wallet-file: src/main/resources/wallets/demo-wallet.json # wallet file location
+  wallet-password: Password123 # wallet file password
+  eth-fund: 10 # only relevant in demo mode
+  private-key: # Private key of the sender's account. (Note: This takes precedence over wallet.)
+  log-level: NONE # NONE, BASIC, HEADERS, BODY
+
+token:
+  name: SecureToken
+  symbol: STK
+  initial-supply: 2 # Total tokens minted (value is multiplied by 10^18)
+  recipient: 45412868cB693e231DfD4ABCCA29D7001501d06f # Tokens would be transferred to this account.
+  amount: 5 # Number of tokens transferred in one transactions
+  gas-price: 4_100_000_000 # gas price
+  gas-limit: 9_000_000 # gas limit
+
+logging:
+  level:
+    com:
+      vmware: info
+    org:
+      web3j:
+        evm: warn
+
+server:
+  port: 8080 # web UI port for tracking progress

--- a/web3j/src/main/resources/static/js/progress.js
+++ b/web3j/src/main/resources/static/js/progress.js
@@ -1,0 +1,96 @@
+/*-
+ * #%L
+ * ERC-20 Load Testing Tool
+ * %%
+ * Copyright (C) 2021 VMware
+ * %%
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ * #L%
+ */
+function LoadProgress() {
+
+  this.source = null;
+
+  this.start = function () {
+
+    this.source = new EventSource("/test/progress");
+
+    this.source.addEventListener("message", function (event) {
+
+      // These events are JSON, so parsing and DOM fiddling are needed
+      const progress = JSON.parse(event.data);
+      updateChart(progress);
+      updateReport(progress);
+    });
+
+    this.source.onerror = function () {
+      this.close();
+    }
+  }
+
+  this.stop = function () {
+    this.source.close();
+  }
+
+}
+
+function updateChart(progress) {
+  config.data.labels.push(new Date());
+  config.data.datasets[0].data.push(progress.currentThroughput);
+  config.data.datasets[1].data.push(progress.currentLatency);
+  chart.update();
+}
+
+function updateReport(progress) {
+  const update = (id, rowIndex, value) => {
+    document.getElementById(
+        id).rows[rowIndex].cells[1].innerHTML = value;
+  };
+
+  update("test", 0, progress.workloadModel);
+  update("test", 1, progress.loadFactor);
+  update("test", 2, progress.elapsedTime);
+  update("test", 3, progress.remainingTime);
+
+  update("transactions", 0, progress.txTotal);
+  update("transactions", 1, progress.txSuccess);
+  update("transactions", 2, progress.txFailure);
+  update("transactions", 3, progress.txErrors);
+  update("transactions", 4, progress.txPending);
+
+  update("metrics", 0, progress.currentThroughput);
+  update("metrics", 1, progress.currentLatency);
+  update("metrics", 2, progress.averageThroughput);
+  update("metrics", 3, progress.averageLatency);
+}
+
+progress = new LoadProgress();
+
+/*
+ * Register callbacks for starting and stopping the SSE controller.
+ */
+window.onload = function () {
+  progress.start();
+  console.log("Progress started")
+}
+
+window.onbeforeunload = function () {
+  progress.stop();
+  console.log("Progress stopped")
+}

--- a/web3j/src/main/resources/templates/report.html
+++ b/web3j/src/main/resources/templates/report.html
@@ -1,0 +1,213 @@
+<!--
+  #%L
+  ERC-20 Load Testing Tool
+  %%
+  Copyright (C) 2021 VMware
+  %%
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+  #L%
+  -->
+<!doctype html>
+<html lang="en" xmlns:th="https://www.thymeleaf.org">
+
+<head>
+  <title>Test Report</title>
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.13.0/moment.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.4"></script>
+
+</head>
+
+<body>
+
+<div class="row">
+  <div style="width:75%; margin-left: 20px">
+    <canvas id="canvas"></canvas>
+  </div>
+  <div>
+    <br>
+    <br>
+    <br>
+    <h4>Ethereum</h4>
+    <table class="table table-dark">
+      <tbody>
+      <tr>
+        <th>Client URL</th>
+        <td th:text="${ethInfo.clientUrl}"></td>
+      </tr>
+      <tr>
+        <th>Client Version</th>
+        <td th:text="${ethInfo.clientVersion}"></td>
+      </tr>
+      <tr>
+        <th>Network Version</th>
+        <td th:text="${ethInfo.networkVersion}"></td>
+      </tr>
+      </tbody>
+    </table>
+
+    <h4>Test</h4>
+    <table class="table table-dark" id="test">
+      <tr>
+        <th>Workload Model</th>
+        <td th:text="${progress.workloadModel}"></td>
+      </tr>
+      <tr>
+        <th>
+          <span th:if="${progress.workloadModel.name() == 'OPEN'}">Arrival Rate (/s)</span>
+          <span th:if="${progress.workloadModel.name() == 'CLOSED'}">Concurrency</span>
+        </th>
+        <td th:text="${progress.loadFactor}"></td>
+      </tr>
+      <tr>
+        <th>Time Elapsed</th>
+        <td th:text="${progress.elapsedTime}"></td>
+      </tr>
+      <tr>
+        <th>Time Remaining</th>
+        <td th:text="${progress.remainingTime}"></td>
+      </tr>
+    </table>
+
+    <h4>Transactions</h4>
+    <table class="table table-dark" id="transactions">
+      <tbody>
+      <tr>
+        <th>Total</th>
+        <td th:text="${progress.txTotal}"></td>
+      </tr>
+      <tr>
+        <th>OK</th>
+        <td th:text="${progress.txSuccess}"></td>
+      </tr>
+      <tr>
+        <th>KO</th>
+        <td th:text="${progress.txFailure}"></td>
+      </tr>
+      <tr>
+        <th>Errors</th>
+        <td th:text="${progress.txErrors}"></td>
+      </tr>
+      <tr>
+        <th>Pending</th>
+        <td th:text="${progress.txPending}"></td>
+      </tr>
+      </tbody>
+    </table>
+
+    <h4>Metrics</h4>
+    <table class="table table-dark" id="metrics">
+      <tr>
+        <th>Current Throughput (/s)</th>
+        <td th:text="${progress.currentThroughput}"></td>
+      </tr>
+      <tr>
+        <th>Current Latency (ms)</th>
+        <td th:text="${progress.currentLatency}"></td>
+      </tr>
+      <tr>
+        <th>Average Throughput (/s)</th>
+        <td th:text="${progress.averageThroughput}"></td>
+      </tr>
+      <tr>
+        <th>Average Latency (ms)</th>
+        <td th:text="${progress.averageLatency}"></td>
+      </tr>
+    </table>
+  </div>
+</div>
+
+<script>
+  const red = 'rgb(255, 99, 132)';
+  const blue = 'rgb(54, 162, 235)';
+
+  const config = {
+    type: 'line',
+    data: {
+      labels: [],
+      datasets: [{
+        label: 'Throughput',
+        backgroundColor: red,
+        borderColor: red,
+        fill: false,
+        data: [],
+        yAxisID: 'A',
+      }, {
+        label: 'Latency',
+        backgroundColor: blue,
+        borderColor: blue,
+        fill: false,
+        data: [],
+        yAxisID: 'B'
+      }]
+    },
+    options: {
+      title: {
+        display: true,
+        text: 'Transaction Metrics'
+      },
+      scales: {
+        xAxes: [{
+          type: 'time',
+          time: {
+            tooltipFormat: 'll HH:mm:ss'
+          },
+          scaleLabel: {
+            display: true,
+            labelString: 'Time'
+          }
+        }],
+        yAxes: [{
+          id: 'A',
+          display: true,
+          position: 'left',
+          scaleLabel: {
+            display: true,
+            labelString: 'Trades/sec'
+          },
+          ticks: {
+            beginAtZero: true
+          }
+        }, {
+          id: 'B',
+          display: true,
+          position: 'right',
+          scaleLabel: {
+            display: true,
+            labelString: 'Latency (ms)'
+          },
+          ticks: {
+            beginAtZero: false
+          }
+        }]
+      }
+    }
+  };
+
+  const ctx = document.getElementById('canvas').getContext('2d');
+  chart = new Chart(ctx, config);
+</script>
+
+<script data-th-src="@{/js/progress.js}"></script>
+
+</body>
+</html>
+
+

--- a/web3j/src/main/resources/wallets/demo-wallet.json
+++ b/web3j/src/main/resources/wallets/demo-wallet.json
@@ -1,0 +1,21 @@
+{
+  "address": "cb0365cd172e1308ad995d5445234b1693b4e9c4",
+  "id": "6e64bbbf-98de-4fca-b53f-2c8fa5ccaa15",
+  "version": 3,
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "ciphertext": "fe9ed5daa7325a974962898f56170b9774f5a60551ab39d608dd36ab035ade1f",
+    "cipherparams": {
+      "iv": "30130e839c78d35c8bde9f4257c78d50"
+    },
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 262144,
+      "p": 1,
+      "r": 8,
+      "salt": "8069b433b227823df6dd0c4ec123cb7727245b65e076e447c290145b06562dd5"
+    },
+    "mac": "6de9da1386e6bc100d0615ddf0bba271a566ed185c8c375831812d33c0a75d51"
+  }
+}


### PR DESCRIPTION
This is a command line tool to load test an Ethereum client. It can be invoked using CLI as mentioned in README. Using web3j, it transfers SecurityToken from one account to another at a controlled pace, i.e. using an open or closed workload model. This tool is suitable to be used for long running test. At end of the test, it produces summarized report including successful & failed transactions and performance metrics like throughput and latency. It also includes a web page to monitor live progress of the test.