### PR TITLE
Minor update to erc20-swap build config

### DIFF
--- a/erc20-swap/Dockerfile
+++ b/erc20-swap/Dockerfile
@@ -16,7 +16,7 @@ COPY . /workspace/erc20-swap
 
 
 # Install Dependencies
-RUN apk add --update nodejs=14.19.0-r0
+RUN apk add --update nodejs=14.20.0-r0
 RUN apk add --update npm=7.17.0-r0
 
 # Run build Commands


### PR DESCRIPTION
ERC20-swap uses Alpine Linux version 3.14 aarch64, which, according
to alpine.pkgs.org and my own building experiences, uses the nodejs
package version 14.20.0-r0 instead of 14.19.0-r0 as prescribed in
the Dockerfile used when building with build.sh. Using the appropriate
version of nodejs will allow the package to build with build.sh.
For more clarity, here is the error I encountered when building:
```
 => ERROR [3/7] RUN apk add --update nodejs=14.19.0-r0                                                                                                                                                                                                   1.0s
------
 > [3/7] RUN apk add --update nodejs=14.19.0-r0:
#7 0.199 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
#7 0.682 fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
#7 0.958 ERROR: unable to select packages:
#7 0.988   nodejs-14.20.0-r0:
#7 0.988     breaks: world[nodejs=14.19.0-r0]
```
Signed-off-by: Kevin Xu <kevinx1@kevinx1-a01.vmware.com>