### PR TITLE
Generic Permission management for Users/Accounts for DApps

### DIFF
--- a/artemis/setup/README.md
+++ b/artemis/setup/README.md
@@ -1,0 +1,33 @@
+# Setup Permissioning
+
+## Configure Setup of Permissioning required for Artemis
+* `config.json` can be modified for any need of setting up of permissioning
+
+### About `config.json`
+
+* `blockchain`: Specify the endpoint of Blockchain
+
+* `permissioning`: Takes details about the permissioning configured in Blockchain
+    * `contractAddress`: Contract address of Permissioning contract (from `genesis.json`)
+    * `adminAccount`: Details about the admin account (one of the accounts from `alloc` in `genesis.json`)
+        * `address`: Address of the admin account
+        * `privateKey`: Private key of the admin account 
+
+* `accounts`: Accounts which need any permissioning handling/setup. This takes an array of accounts with permission details
+    * `address`: Address of the account
+    * `privateKey`: Private key of the account
+    * `permissions` : Permission details
+        * `addPermissions`: Permissions needed to be added. Takes "READ", "WRITE" and "DEPLOY" as parameters
+        * `removePermissions`: Permissions needed to be removed. Takes "READ", "WRITE" and "DEPLOY" as parameters
+
+
+## Quick Steps
+```sh
+# Install required dependency packages
+npm install
+
+# Configure config.json
+
+# Run following to setup permissioning
+node setup-permissioning.js
+```

--- a/artemis/setup/config.json
+++ b/artemis/setup/config.json
@@ -1,0 +1,30 @@
+{
+    "blockchain": {
+        "url": "http://localhost:8545"
+    },
+    "permissioning": {
+        "contractAddress": "",
+        "adminAccount": {
+            "address": "",
+            "privateKey": ""
+        }
+    },
+    "accounts": [
+        {
+            "address": "",
+            "privateKey": "",
+            "permissions": {
+                "addPermissions": ["DEPLOY"],
+                "removePermissions": []
+            }
+        },
+        {
+            "address": "",
+            "privateKey": "",
+            "permissions": {
+                "addPermissions": ["WRITE", "DEPLOY"],
+                "removePermissions": []
+            }
+        }
+    ]
+}

--- a/artemis/setup/package.json
+++ b/artemis/setup/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "setup_and_deploy_dapps",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "dependencies": {
+        "ethers": "5.6.9",
+        "console": "0.7.2",
+        "dotenv": "16.0.1",
+        "fs": "0.0.1-security",
+        "fs-extra": "^10.1.0",
+        "solc": "^0.8.15"
+    }
+}

--- a/artemis/setup/setup-permissioning.js
+++ b/artemis/setup/setup-permissioning.js
@@ -1,0 +1,152 @@
+const ethers = require("@vmware-blockchain/ethers");
+
+var setupConfig = require('./config.json');
+
+var permissionTypes = {
+    "READ": 1,
+    "WRITE": 2,
+    "DEPLOY": 4
+}
+
+var VMBC_URL = setupConfig.blockchain.url;
+
+let PROVIDER;
+let ADMIN_WALLET;
+
+let ADMIN_ACCOUNT_PRIVATE_KEY = String(setupConfig.permissioning.adminAccount.privateKey);
+let PERMISSIONING_CONTRACT_ADDRESS = String(setupConfig.permissioning.contractAddress);
+let PERMISSIONING_CONTRACT_ABI = [
+    "function updatePermissions(address from, address to, uint8 action, bool remove)", 
+    "function checkUserAction(address from, address to, uint8 action) external view returns(bool)"
+];
+
+function checkConfig() {
+    if ((ADMIN_ACCOUNT_PRIVATE_KEY === "") || (PERMISSIONING_CONTRACT_ADDRESS === "")) {
+        console.log("privateKey and contractAddress of permissioning is mandatory to provide in config");
+        return false;
+    }
+    return true;
+}
+
+function setupAdminProviderAndWallet() {
+    PROVIDER = new ethers.providers.JsonRpcProvider(VMBC_URL);
+    ADMIN_WALLET = new ethers.Wallet(ADMIN_ACCOUNT_PRIVATE_KEY, PROVIDER);
+}
+
+function processPermissions(permArr) {
+    let perm = 0;
+    if (permArr.includes("READ", 0)) {
+        perm += permissionTypes.READ;
+    }
+    if (permArr.includes("WRITE", 0)) {
+        perm += permissionTypes.WRITE;
+    }
+    if (permArr.includes("DEPLOY", 0)) {
+        perm += permissionTypes.DEPLOY;
+    }
+    return perm;
+}
+
+const checkHasRequiredPermissions = async (account, allPermissions) => {
+    if (account.privateKey === "") {
+        console.log("Private key is not provided for " + account.address);
+        console.log("Skipping checking existing permissions");
+        return false;
+    } else {
+        return await checkPermissions(account, allPermissions)
+    }
+}
+
+const addPermissions = async (account, allPermissions) => {
+    if (allPermissions > 0) {
+        // Check for existing permissions
+        var hasRequiredPermissions = await checkHasRequiredPermissions(account, allPermissions);
+        if (!hasRequiredPermissions) {
+            return updatePermissions(account.address, allPermissions, 0);
+        }
+    } else if (allPermissions === 0) {
+        console.log("No permissions to add");
+    }
+}
+
+// Todo: needPermissionUpdate can be implemented and utilized for removePermissions as well
+const removePermissions = async (account, allPermissions) => {
+    if (allPermissions > 0) {
+        return updatePermissions(account.address, allPermissions, 1);
+    } else if (allPermissions === 0) {
+        console.log("No permissions to remove");
+    }
+}
+
+const checkPermissions = async (account, allPermissions) => {
+    console.log("Checking permissions for " + account.address);
+    let privateKey = String(account.privateKey);
+    let fromAddress = account.address;
+    
+    let toAddress = "0x0000000000000000000000000000000000000000";
+    let ACCOUNT_WALLET = new ethers.Wallet(privateKey, PROVIDER);
+    const contract = new ethers.Contract(PERMISSIONING_CONTRACT_ADDRESS, PERMISSIONING_CONTRACT_ABI, PROVIDER);
+    const contractWithSigner = contract.connect(ACCOUNT_WALLET);
+    var response = "";
+    try {
+        response = await contractWithSigner.checkUserAction(fromAddress, toAddress, allPermissions);
+    } catch (error) {
+        console.log("Error while calling set()...");
+        console.log(error);
+        process.exit(1);
+    }
+    if (response) {
+        console.log("\x1b[34m%s\x1b[0m", "Account "+ fromAddress + " already has required permissions.");
+        console.log("");
+        return true;
+    } else {
+        console.log("\x1b[34m%s\x1b[0m", "Account "+ fromAddress + " does not have required permissions.");
+        return false;
+    }
+}
+
+const updatePermissions = async (accAddr, allPermissions, addOrRemove) => {
+    console.log("Updating permissions for " + accAddr);
+    let fromAddress = accAddr;
+    let toAddress = "0x0000000000000000000000000000000000000000";
+
+    const contract = new ethers.Contract(PERMISSIONING_CONTRACT_ADDRESS, PERMISSIONING_CONTRACT_ABI, PROVIDER);
+    const contractWithSigner = contract.connect(ADMIN_WALLET);
+    let tx = "";
+    try {
+        tx = await contractWithSigner.updatePermissions(fromAddress, toAddress, allPermissions, addOrRemove);
+    } catch (error) {
+        console.log("Error while calling set()...");
+        console.log(error);
+        process.exit(1);
+    }
+    const txReceipt = await tx.wait();
+    if (txReceipt) {
+        console.log("\x1b[34m%s\x1b[0m", "Permission updated for " + fromAddress)
+        console.log("\x1b[34m%s\x1b[0m",  "Transaction hash: " + tx.hash);
+        console.log("");
+        return true;
+    }
+    return false;
+}
+
+const main = async () => {
+    var isConfigProvided = checkConfig();
+    if (isConfigProvided === false) {
+        console.log("Provide the required config and try again");
+        process.exit(1);
+    }
+
+    console.log("setupConfig is " + JSON.stringify(setupConfig));
+
+    setupAdminProviderAndWallet()
+
+    // Add or Remove required permissions
+    for (var account of setupConfig.accounts) {
+        console.log("account is " + JSON.stringify(account))
+        await addPermissions(account, processPermissions(account.permissions.addPermissions));
+        await removePermissions(account, processPermissions(account.permissions.removePermissions));
+    }
+}
+
+main();


### PR DESCRIPTION
Permissioning Management and Setup for Accounts used DApps
* Generic config.json way to handle permissioning needs for DApps
* Following are few of the need examples
    * `DEPLOY` access for account(s) deploying the Smart Contract(s) for DApp
    * `WRITE` access for account(s) which need to perform any transactions on Blockchain
* Can be used as a pattern by other DApps & CI or/and can be extended to a generic package based config.json as a path based utility for multiple DApps. (This is is the initial implementation of permission management for DApps)