### PR TITLE
Update web3j client auth example to perform write ops as well

### DIFF
--- a/vmbc-ethereum/permissioning/sample-dapps/authentication/web3j-dapp/src/main/java/com/vmware/Incrementer.java
+++ b/vmbc-ethereum/permissioning/sample-dapps/authentication/web3j-dapp/src/main/java/com/vmware/Incrementer.java
@@ -1,0 +1,170 @@
+package com.vmware;
+
+import io.reactivex.Flowable;
+import io.reactivex.functions.Function;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.web3j.abi.EventEncoder;
+import org.web3j.abi.FunctionEncoder;
+import org.web3j.abi.TypeReference;
+import org.web3j.abi.datatypes.Event;
+import org.web3j.abi.datatypes.Type;
+import org.web3j.abi.datatypes.generated.Uint256;
+import org.web3j.crypto.Credentials;
+import org.web3j.protocol.Web3j;
+import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.RemoteCall;
+import org.web3j.protocol.core.RemoteFunctionCall;
+import org.web3j.protocol.core.methods.request.EthFilter;
+import org.web3j.protocol.core.methods.response.BaseEventResponse;
+import org.web3j.protocol.core.methods.response.Log;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
+import org.web3j.tx.Contract;
+import org.web3j.tx.TransactionManager;
+import org.web3j.tx.gas.ContractGasProvider;
+
+/**
+ * <p>Auto generated code.
+ * <p><strong>Do not modify!</strong>
+ * <p>Please use the <a href="https://docs.web3j.io/command_line.html">web3j command line tools</a>,
+ * or the org.web3j.codegen.SolidityFunctionWrapperGenerator in the 
+ * <a href="https://github.com/web3j/web3j/tree/master/codegen">codegen module</a> to update.
+ *
+ * <p>Generated with web3j version 1.4.2.
+ * The below command was used to generate this file while using web3j-dapp as the working directory.
+ * web3j generate solidity -b ../lib/Incrementer.bin -a ../lib/Incrementer.abi -o src/main/java/com/vmware/ -p com.vmware
+ */
+@SuppressWarnings("rawtypes")
+public class Incrementer extends Contract {
+    public static final String BINARY = "608060405234801561001057600080fd5b5060405161018c38038061018c83398101604081905261002f91610037565b600055610050565b60006020828403121561004957600080fd5b5051919050565b61012d8061005f6000396000f3fe6080604052348015600f57600080fd5b5060043610603c5760003560e01c80637cf5dab01460415780638381f58a146052578063d826f88f14606c575b600080fd5b6050604c36600460b9565b6074565b005b605a60005481565b60405190815260200160405180910390f35b605060008055565b806000546080919060d1565b6000556040518181527f51af157c2eee40f68107a47a49c32fbbeb0a3c9e5cd37aa56e88e6be92368a819060200160405180910390a150565b60006020828403121560ca57600080fd5b5035919050565b8082018082111560f157634e487b7160e01b600052601160045260246000fd5b9291505056fea2646970667358221220da062e8fcd880139547c89dbb538e0d890d659ae38a036aabda994ed80a69f7764736f6c63430008110033";
+
+    public static final String FUNC_INCREMENT = "increment";
+
+    public static final String FUNC_NUMBER = "number";
+
+    public static final String FUNC_RESET = "reset";
+
+    public static final Event INCREMENT_EVENT = new Event("Increment", 
+            Arrays.<TypeReference<?>>asList(new TypeReference<Uint256>() {}));
+    ;
+
+    @Deprecated
+    protected Incrementer(String contractAddress, Web3j web3j, Credentials credentials, BigInteger gasPrice, BigInteger gasLimit) {
+        super(BINARY, contractAddress, web3j, credentials, gasPrice, gasLimit);
+    }
+
+    protected Incrementer(String contractAddress, Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider) {
+        super(BINARY, contractAddress, web3j, credentials, contractGasProvider);
+    }
+
+    @Deprecated
+    protected Incrementer(String contractAddress, Web3j web3j, TransactionManager transactionManager, BigInteger gasPrice, BigInteger gasLimit) {
+        super(BINARY, contractAddress, web3j, transactionManager, gasPrice, gasLimit);
+    }
+
+    protected Incrementer(String contractAddress, Web3j web3j, TransactionManager transactionManager, ContractGasProvider contractGasProvider) {
+        super(BINARY, contractAddress, web3j, transactionManager, contractGasProvider);
+    }
+
+    public static List<IncrementEventResponse> getIncrementEvents(TransactionReceipt transactionReceipt) {
+        List<Contract.EventValuesWithLog> valueList = staticExtractEventParametersWithLog(INCREMENT_EVENT, transactionReceipt);
+        ArrayList<IncrementEventResponse> responses = new ArrayList<IncrementEventResponse>(valueList.size());
+        for (Contract.EventValuesWithLog eventValues : valueList) {
+            IncrementEventResponse typedResponse = new IncrementEventResponse();
+            typedResponse.log = eventValues.getLog();
+            typedResponse._value = (BigInteger) eventValues.getNonIndexedValues().get(0).getValue();
+            responses.add(typedResponse);
+        }
+        return responses;
+    }
+
+    public Flowable<IncrementEventResponse> incrementEventFlowable(EthFilter filter) {
+        return web3j.ethLogFlowable(filter).map(new Function<Log, IncrementEventResponse>() {
+            @Override
+            public IncrementEventResponse apply(Log log) {
+                Contract.EventValuesWithLog eventValues = extractEventParametersWithLog(INCREMENT_EVENT, log);
+                IncrementEventResponse typedResponse = new IncrementEventResponse();
+                typedResponse.log = log;
+                typedResponse._value = (BigInteger) eventValues.getNonIndexedValues().get(0).getValue();
+                return typedResponse;
+            }
+        });
+    }
+
+    public Flowable<IncrementEventResponse> incrementEventFlowable(DefaultBlockParameter startBlock, DefaultBlockParameter endBlock) {
+        EthFilter filter = new EthFilter(startBlock, endBlock, getContractAddress());
+        filter.addSingleTopic(EventEncoder.encode(INCREMENT_EVENT));
+        return incrementEventFlowable(filter);
+    }
+
+    public RemoteFunctionCall<TransactionReceipt> increment(BigInteger _value) {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(
+                FUNC_INCREMENT, 
+                Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(_value)), 
+                Collections.<TypeReference<?>>emptyList());
+        return executeRemoteCallTransaction(function);
+    }
+
+    public RemoteFunctionCall<BigInteger> number() {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(FUNC_NUMBER, 
+                Arrays.<Type>asList(), 
+                Arrays.<TypeReference<?>>asList(new TypeReference<Uint256>() {}));
+        return executeRemoteCallSingleValueReturn(function, BigInteger.class);
+    }
+
+    public RemoteFunctionCall<TransactionReceipt> reset() {
+        final org.web3j.abi.datatypes.Function function = new org.web3j.abi.datatypes.Function(
+                FUNC_RESET, 
+                Arrays.<Type>asList(), 
+                Collections.<TypeReference<?>>emptyList());
+        return executeRemoteCallTransaction(function);
+    }
+
+    @Deprecated
+    public static Incrementer load(String contractAddress, Web3j web3j, Credentials credentials, BigInteger gasPrice, BigInteger gasLimit) {
+        return new Incrementer(contractAddress, web3j, credentials, gasPrice, gasLimit);
+    }
+
+    @Deprecated
+    public static Incrementer load(String contractAddress, Web3j web3j, TransactionManager transactionManager, BigInteger gasPrice, BigInteger gasLimit) {
+        return new Incrementer(contractAddress, web3j, transactionManager, gasPrice, gasLimit);
+    }
+
+    public static Incrementer load(String contractAddress, Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider) {
+        return new Incrementer(contractAddress, web3j, credentials, contractGasProvider);
+    }
+
+    public static Incrementer load(String contractAddress, Web3j web3j, TransactionManager transactionManager, ContractGasProvider contractGasProvider) {
+        return new Incrementer(contractAddress, web3j, transactionManager, contractGasProvider);
+    }
+
+    public static RemoteCall<Incrementer> deploy(Web3j web3j, Credentials credentials, ContractGasProvider contractGasProvider, BigInteger _initialNumber) {
+        String encodedConstructor = FunctionEncoder.encodeConstructor(Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(_initialNumber)));
+        return deployRemoteCall(Incrementer.class, web3j, credentials, contractGasProvider, BINARY, encodedConstructor);
+    }
+
+    public static RemoteCall<Incrementer> deploy(Web3j web3j, TransactionManager transactionManager, ContractGasProvider contractGasProvider, BigInteger _initialNumber) {
+        String encodedConstructor = FunctionEncoder.encodeConstructor(Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(_initialNumber)));
+        return deployRemoteCall(Incrementer.class, web3j, transactionManager, contractGasProvider, BINARY, encodedConstructor);
+    }
+
+    @Deprecated
+    public static RemoteCall<Incrementer> deploy(Web3j web3j, Credentials credentials, BigInteger gasPrice, BigInteger gasLimit, BigInteger _initialNumber) {
+        String encodedConstructor = FunctionEncoder.encodeConstructor(Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(_initialNumber)));
+        return deployRemoteCall(Incrementer.class, web3j, credentials, gasPrice, gasLimit, BINARY, encodedConstructor);
+    }
+
+    @Deprecated
+    public static RemoteCall<Incrementer> deploy(Web3j web3j, TransactionManager transactionManager, BigInteger gasPrice, BigInteger gasLimit, BigInteger _initialNumber) {
+        String encodedConstructor = FunctionEncoder.encodeConstructor(Arrays.<Type>asList(new org.web3j.abi.datatypes.generated.Uint256(_initialNumber)));
+        return deployRemoteCall(Incrementer.class, web3j, transactionManager, gasPrice, gasLimit, BINARY, encodedConstructor);
+    }
+
+    public static class IncrementEventResponse extends BaseEventResponse {
+        public BigInteger _value;
+    }
+}
+

--- a/vmbc-ethereum/permissioning/sample-dapps/authentication/web3j-dapp/src/main/java/com/vmware/SampleDappHttps.java
+++ b/vmbc-ethereum/permissioning/sample-dapps/authentication/web3j-dapp/src/main/java/com/vmware/SampleDappHttps.java
@@ -1,27 +1,23 @@
 package com.vmware;
 
+import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
-import okhttp3.OkHttpClient;
-import okhttp3.OkHttpClient.Builder;
-import org.json.JSONArray;
 import org.json.JSONObject;
+import org.web3j.crypto.Credentials;
+import org.web3j.crypto.ECKeyPair;
+import org.web3j.crypto.Keys;
 import org.web3j.protocol.Web3j;
-import org.web3j.protocol.core.methods.response.EthAccounts;
-import org.web3j.protocol.core.methods.response.EthBlockNumber;
 import org.web3j.protocol.core.methods.response.EthGasPrice;
+import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.http.HttpService;
+import org.web3j.tx.gas.DefaultGasProvider;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
-import java.io.File;
+import javax.net.ssl.*;
 import java.io.FileReader;
 import java.io.IOException;
+import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -33,9 +29,6 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
-
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class SampleDappHttps {
 
@@ -130,6 +123,17 @@ public class SampleDappHttps {
         EthGasPrice ethGasPrice = web3j.ethGasPrice().send();
         System.out.println(ethGasPrice.getRawResponse());
 
+        // Create keypair
+        ECKeyPair keyPair =  Keys.createEcKeyPair();
+        Credentials credentials = Credentials.create(keyPair);
+
+        // Deploy contract
+        Incrementer incrementer = Incrementer.deploy(web3j,credentials, new DefaultGasProvider(), BigInteger.ONE).send();
+
+        // Do write operation on contract
+        TransactionReceipt tr = incrementer.increment(BigInteger.TWO).send();
+        System.out.println("Successfully executed transaction. Transaction hash: " + tr.getTransactionHash());
+
         // Clear the connection pool
         okHttpClient.connectionPool().evictAll();
     }
@@ -140,3 +144,4 @@ public class SampleDappHttps {
         return keyStore;
     }
 }
+

--- a/vmbc-ethereum/permissioning/sample-dapps/authentication/web3j-dapp/src/main/java/com/vmware/SampleDappHttps.java
+++ b/vmbc-ethereum/permissioning/sample-dapps/authentication/web3j-dapp/src/main/java/com/vmware/SampleDappHttps.java
@@ -109,7 +109,18 @@ public class SampleDappHttps {
                         .body(ResponseBody.create(response.body().bytes(), response.body().contentType()))
                         .build();
             });
-        }
+        } else {
+            okHttpClientBuilder = okHttpClientBuilder
+            .addInterceptor(chain -> {
+                Request request = chain.request().newBuilder()
+                        .build();
+                Response response = chain.proceed(request);
+                return response.newBuilder()
+                        // Retrieve the full response
+                        .body(ResponseBody.create(response.body().bytes(), response.body().contentType()))
+                        .build();
+            });
+	}
         
         OkHttpClient okHttpClient = okHttpClientBuilder.build();
 


### PR DESCRIPTION
Web3j example for client authentication currently performs only a read operation. With this change it would now deploy a contract (same Increment.sol contract used in the other Javascrip examples) and call a functino to increment a value. This write operation will also allow us to better demonstrate the working of the websocket example for web3j.